### PR TITLE
minimal issue write on start fails

### DIFF
--- a/GDI-4ch/firmware/main.cpp
+++ b/GDI-4ch/firmware/main.cpp
@@ -117,15 +117,17 @@ int main() {
     InitCan();
     InitUart();
 
+    saveConfiguration();
+
 	palSetPadMode(LED_BLUE_PORT, LED_BLUE_PIN, PAL_MODE_OUTPUT_PUSHPULL);
 	palClearPad(LED_BLUE_PORT, LED_BLUE_PIN);
 	palSetPadMode(LED_GREEN_PORT, LED_GREEN_PIN, PAL_MODE_OUTPUT_PUSHPULL);
 	palClearPad(LED_GREEN_PORT, LED_GREEN_PIN);
 
-    bool isOverallHappyStatus = false;
+    bool isOverallHappyStatus = true;//false;
 
     // reminder that +12v is required for PT2001 to start
-	isOverallHappyStatus = chip.init();
+	//isOverallHappyStatus = chip.init();
 
     while (true) {
         if (isOverallHappyStatus) {


### PR DESCRIPTION
```
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 447 CAN o/e 3 836
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 448 CAN o/e 3 837
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 449 CAN o/e 3 839
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 450 CAN o/e 3 841
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 451 CAN o/e 3 843
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 452 CAN o/e 3 845
BB30 5000 21 HAPPY fault=0 status=0 status2=0 flash=-8 453 CAN o/e 3 847
```

@dron0gus  ``flash=-8``  is unexpected :( reproducible on real stm32 256Kb